### PR TITLE
Use async asynchronously to fix max call stack

### DIFF
--- a/cursor/populateBuffers.js
+++ b/cursor/populateBuffers.js
@@ -65,7 +65,7 @@ module.exports = function populateBuffers(options, cb) {
           }
 
           buffers.add(buffer);
-          nextParent();
+          async.setImmediate(nextParent);
         }, nextPop);
 
       }, next);


### PR DESCRIPTION
This resolves #3 by implementing @ilya-khaustov's fix described here: https://github.com/balderdashy/waterline-cursor/issues/2#issue-49024180

The issue is that async is being used with a synchronous function.  See: https://github.com/caolan/async/pull/588.

Note, there may be a better fix of refactoring code to not use async when it's not necessary.
