### PR TITLE
Add integration tests to waterline-cursor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+
+node_js:
+  - 0.10
+  - 0.11

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+ROOT=$(shell pwd)
+
+test: test-integration
+  
+test-integration:
+	@echo "\nRunning integration tests..."
+	rm -rf node_modules/sails-memory/node_modules/waterline-cursor
+	ln -s $(ROOT) node_modules/sails-memory/node_modules/waterline-cursor
+	rm -rf node_modules/sails-disk/node_modules/waterline-cursor
+	ln -s $(ROOT) node_modules/sails-disk/node_modules/waterline-cursor
+	@NODE_ENV=test node test/integration/runnerDispatcher.js

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 waterline-cursor
 ================
+[![Build Status](https://travis-ci.org/balderdashy/waterline-cursor.svg?branch=master)](https://travis-ci.org/balderdashy/waterline-cursor)
+[![npm version](https://badge.fury.io/js/waterline-cursor.svg)](http://badge.fury.io/js/waterline-cursor)
+[![Dependency Status](https://david-dm.org/balderdashy/waterline-cursor.svg)](https://david-dm.org/balderdashy/waterline-cursor)
 
 Association/subquery helper

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "make test"
   },
   "keywords": [
     "waterline",
@@ -16,5 +16,15 @@
   "dependencies": {
     "async": "~0.9.0",
     "lodash": "~2.4.1"
+  },
+  "devDependencies": {
+    "async": "^0.9.0",
+    "jpath": "^0.0.20",
+    "lodash": "^2.4.1",
+    "mocha": "^2.2.4",
+    "npm": "^2.8.3",
+    "sails-disk": "balderdashy/sails-disk",
+    "sails-memory": "balderdashy/sails-memory",
+    "waterline-adapter-tests": "^0.10.10"
   }
 }

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,27 @@
+Integration tests
+==========================
+[![Build Status](https://travis-ci.org/balderdashy/waterline-cursor.svg?branch=master)](https://travis-ci.org/balderdashy/waterline-cursor)
+
+
+A set of integration tests that test the sails-memory and sails-disk adapters against waterline-cursor edge version.
+
+
+## Goals
+
+ * Detect if a change in waterline-cursor breaks any dependent adapter tests;
+ * Test using the edge version of waterline-cursor and the adapters to ensure the current snapshot of all these are working together and consequently are OK to release;
+ * make it easier for waterline-cursor developers to test changes against the dependent adapters.
+
+
+## What's the difference between these tests and the ones ran by the individual adapters?
+
+The adapters are configured to run their tests against the **stable** version of waterline-cursor. From an adapter point of 
+view, this makes sense since the adapter is only responsible for supporting the stable versions of its dependencies. 
+These tests run against waterline-cursor **edge** version (latest in github) and the objective is to prevent changes in 
+waterline-cursor to accidently break the adapters.
+
+
+## What's the difference between these tests and the waterline-adapter-tests?
+
+The set of integration tests in waterline-adapter-tests test waterline core **edge** against the adapters **edge** versions. These tests tests waterline-cursor **edge** against the adapters **edge** versions using waterline core **stable**. While the former is targeted at waterline core developers the later is targeted waterline-cursor developers.
+

--- a/test/integration/customDotReporter.js
+++ b/test/integration/customDotReporter.js
@@ -1,0 +1,66 @@
+/**
+ * Module dependencies.
+ */
+
+var Mocha = require('mocha')
+  , Base = Mocha.reporters.Base
+  , color = Base.color;
+
+// allow to force the use of colors
+Base.useColors = process.env.FORCE_COLORS ? true : Base.useColors;
+
+/**
+ * Expose `Dot`.
+ */
+
+exports = module.exports = Dot;
+
+/**
+ * Initialize a new `Dot` matrix test reporter.
+ *
+ * @param {Runner} runner
+ * @api public
+ */
+
+function Dot(runner) {
+  Base.call(this, runner);
+
+  var self = this
+    , stats = this.stats
+    , width = Base.window.width * .75 | 0
+    , n = -1;
+
+  runner.on('start', function(){
+    process.stdout.write('\n');
+  });
+
+  runner.on('pending', function(test){
+    if (++n % width == 0) process.stdout.write('\n  ');
+    process.stdout.write(color('pending', Base.symbols.dot));
+  });
+
+  runner.on('pass', function(test){
+    if (++n % width == 0) process.stdout.write('\n  ');
+    if ('slow' == test.speed) {
+      process.stdout.write(color('bright yellow', Base.symbols.dot));
+    } else {
+      process.stdout.write(color(test.speed, Base.symbols.dot));
+    }
+  });
+
+  runner.on('fail', function(test, err){
+    if (++n % width == 0) process.stdout.write('\n  ');
+    process.stderr.write(color('fail', Base.symbols.dot));
+  });
+
+  runner.on('end', function(){
+    console.log();
+    self.epilogue();
+  });
+}
+
+/**
+ * Inherit from `Base.prototype`.
+ */
+
+Dot.prototype.__proto__ = Base.prototype;

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -1,0 +1,92 @@
+/**
+ * Test runner dependencies
+ */
+var util = require('util');
+var mocha = require('mocha');
+var customDotReporter = require('./customDotReporter');
+
+var adapterName = process.env.ADAPTER_NAME || process.argv[2];
+var TestRunner = require('waterline-adapter-tests');
+var Adapter = require(adapterName);
+var config = { schema: false };
+
+
+// Grab targeted interfaces from this adapter's `package.json` file:
+var package = {};
+var interfaces = [];
+try {
+    package = require('../../node_modules/' + adapterName + '/package.json');
+    interfaces = package['waterlineAdapter'].interfaces;
+}
+catch (e) {
+    throw new Error(
+    '\n'+
+    'Could not read supported interfaces from "sails-adapter"."interfaces"'+'\n' +
+    'in this adapter\'s `package.json` file ::' + '\n' +
+    util.inspect(e)
+    );
+}
+
+
+
+
+
+console.info('Testing `' + package.name + '`, a Sails adapter.');
+console.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
+console.info('( ' + interfaces.join(', ') + ' )');
+console.log();
+console.log('Latest draft of Waterline adapter interface spec:');
+console.info('https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md');
+console.log();
+
+
+
+
+/**
+ * Integration Test Runner
+ *
+ * Uses the `waterline-adapter-tests` module to
+ * run mocha tests against the specified interfaces
+ * of the currently-implemented Waterline adapter API.
+ */
+new TestRunner({
+
+    // Load the adapter module.
+    adapter: Adapter,
+
+    // Default adapter config to use.
+    config: config,
+
+    // The set of adapter interfaces to test against.
+    // (grabbed these from this adapter's package.json file above)
+    interfaces: interfaces,
+    
+    // Mocha options
+    // reference: https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically
+    mocha: {
+      reporter: customDotReporter
+    },
+    
+    mochaChainableMethods: {},
+    
+    // Return code != 0 if any test failed
+    failOnError: true
+    
+    // Most databases implement 'semantic' and 'queryable'.
+    // 
+    // As of Sails/Waterline v0.10, the 'associations' interface
+    // is also available.  If you don't implement 'associations',
+    // it will be polyfilled for you by Waterline core.  The core
+    // implementation will always be used for cross-adapter / cross-connection
+    // joins.
+    // 
+    // In future versions of Sails/Waterline, 'queryable' may be also
+    // be polyfilled by core.
+    // 
+    // These polyfilled implementations can usually be further optimized at the
+    // adapter level, since most databases provide optimizations for internal
+    // operations.
+    // 
+    // Full interface reference:
+    // https://github.com/balderdashy/sails-docs/blob/master/contributing/adapter-specification.md
+});

--- a/test/integration/runnerDispatcher.js
+++ b/test/integration/runnerDispatcher.js
@@ -1,0 +1,170 @@
+var exec = require('child_process').exec;
+var async = require('async');
+var npm = require('npm');
+var jpath = require('jpath');
+
+
+/////////////////////////////////////////////////////////////////////
+//
+// Config
+
+// The adapters being tested
+var adapters = ['sails-memory', 'sails-disk'];
+
+// Core modules npm Dependencies path
+var coreModulesPaths = {
+  "waterline":               ".dependencies.waterline-adapter-tests.dependencies.waterline",
+  "- anchor":                ".dependencies.waterline-adapter-tests.dependencies.waterline.dependencies.anchor",
+  "- waterline-schema":      ".dependencies.waterline-adapter-tests.dependencies.waterline.dependencies.waterline-schema",
+  "waterline-adapter-tests": ".dependencies.waterline-adapter-tests"
+};
+
+var wlCursorPath = ".";
+
+//
+/////////////////////////////////////////////////////////////////////
+
+
+var status = {},
+    npmData,
+    exitCode = 0;
+process.env.FORCE_COLORS = true;
+
+console.time('total time elapsed');
+
+var resultTable = "\n";
+resultTable += " ------------------------------------------------------------------- \n";
+resultTable += "| adapter          | version | status  | failed | total | wl-cursor |\n";
+resultTable += "|------------------|---------|---------|--------|-------|-----------|\n";
+
+function getNpmDetails(cb){
+  npm.load({ depth: 2 }, function (er) {
+  if (er) return process.exit(1);
+
+  npm.commands.ls('', true, function(err, data){
+    npmData = data;
+    cb(err, data);
+  });
+});
+}
+
+function runTests(cb){
+  async.eachSeries(adapters, function(adapterName, next){
+    status[adapterName] = { failed: 0, total: 0, exitCode: 0 };
+    
+    console.log("\n");
+    console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
+    console.log("\033[0;34m                                     %s \033[0m", adapterName);
+    console.log("\033[0;34m-------------------------------------------------------------------------------------------\033[0m");
+    console.log();
+    
+    var child = exec('node ./test/integration/runner.js ' + adapterName, { env: process.env });
+    child.stdout.on('data', function(data) {
+      if(isDot(data)) { status[adapterName].total++; }
+      process.stdout.write(data);
+    });
+    child.stderr.on('data', function(data) {
+      if(isDot(data)) { 
+        status[adapterName].total++;
+        status[adapterName].failed++;
+      }
+      process.stdout.write(data);
+    });
+    child.on('close', function(code) {
+      status[adapterName].exitCode = code;
+      var message = code == 0 ? "\033[0;32msuccess\033[0m" : "\033[0;31mfailed \033[0m";
+      var wlCursor = getWlCursorVersion(adapterName);
+      resultTable += "| " + padRight(adapterName, 16) 
+        + " | " + padLeft(processVersion(npmData.dependencies[adapterName]), 7)
+        + " | " + message 
+        + " | " + padLeft(status[adapterName].failed, 6) 
+        + " | " + padLeft(status[adapterName].total, 5)
+        + " | " + padLeft(wlCursor, 9)
+        + " |\n";
+      
+      console.log('exit code: ' + code);
+      if(code != 0) { exitCode = code; }
+      next();
+    });
+  }, 
+  cb);
+}
+
+function printCoreModulesVersions(cb){
+  var coreModules = "\n";
+  coreModules += " ----------------------------------- \n";
+  coreModules += "| core modules            | version |\n";
+  coreModules += "|-------------------------|---------|\n";
+  for(var moduleName in coreModulesPaths){
+    coreModules += getModuleRow(moduleName, jpath(npmData, coreModulesPaths[moduleName])[0]);
+  }
+  coreModules += " ----------------------------------- \n";
+  console.log(coreModules);
+  cb();
+}
+
+function getModuleRow(name, module){;
+  return "| "+ padRight(name, 23) + " | " 
+    + padLeft(processVersion(module), 7) 
+    + " |\n";
+}
+
+
+async.series([getNpmDetails, runTests, printCoreModulesVersions], function(err, res){
+  resultTable += " ------------------------------------------------------------------- \n";
+  console.log(resultTable);
+  console.timeEnd('total time elapsed');
+  if(err){
+    console.error('Something wrong happened:', err);
+  }
+  process.exit(exitCode);
+});
+
+
+
+/**
+ * Aux functions
+ */
+function isDot(data){
+  return data == '․' || (data.length === 10 /*&& data[0] === '\u001b'*/ && data.charAt(5) === '․'.charAt(0));
+}
+
+function padRight(str, padding){
+  var res = "" + str;
+  for(var i=res.length; i<padding; i++){
+    res += ' ';
+  }
+  return res;
+}
+
+function padLeft(str, padding){
+  str = str + "";
+  var pad = "";
+  for(var i=str.length; i<padding; i++){
+    pad += ' ';
+  }
+  return pad + str;
+};
+
+function processVersion(dependency){
+  if(!dependency) return '';
+  if(dependency._resolved){
+    if(dependency._resolved.indexOf('git') === 0){
+      var parts = dependency._resolved.split('#');
+      return parts[parts.length-1].slice(0, 7);
+    }
+    if(dependency._resolved.indexOf('npmjs.org') >= 0){
+      return dependency.version;
+    }
+  }
+  if(dependency.gitHead){
+    return dependency.gitHead.slice(0, 7);
+  }
+  // console.warn('WARN: Not sure we found the dependency that was resolved.');
+  return dependency.version;
+}
+
+function getWlCursorVersion(adapterName){
+  var path = wlCursorPath.replace('%s', adapterName);
+  return processVersion(jpath(npmData, path)[0]);
+}


### PR DESCRIPTION
In similar fashion to balderdashy/waterline-sequel#32 and balderdashy/waterline-adapter-tests#36 add integration tests to waterline-cursor. These tests run the sails-memory and sails-disk tests using the latest github version of waterline-cursor providing an early warning mechanism.
