### PR TITLE
Populate needs to populate more than just first row

### DIFF
--- a/cursor/cursor.js
+++ b/cursor/cursor.js
@@ -81,11 +81,15 @@ Cursor.prototype.attachRecords = function attachRecords(cb) {
   _.each(bufferedRecords, function (buffer) {
 
     var matchingParentRecord = _.find(parentRecords, function (parentRecord) {
-      return parentRecord[buffer.parentPkAttr] === buffer.belongsToPKValue;
+      return parentRecord[buffer.parentPkAttr] === buffer.belongsToPKValue && !matchingParentRecord.found;
     });
 
     // This should always be true, but checking just in case.
     if (_.isObject(matchingParentRecord)) {
+	  // Once a matchingParentRecord is found, we need to mark it as such, so
+	  // that next iterations through the buffer will find the appropriate
+	  // subsequent matching rows instead of the first match over and over.
+	  matchingParentRecord.found = true;
 
       // If the value in `attrName` for this record is not an array,
       // it is probably a foreign key value.  Fortunately, at this point

--- a/cursor/cursor.js
+++ b/cursor/cursor.js
@@ -81,7 +81,7 @@ Cursor.prototype.attachRecords = function attachRecords(cb) {
   _.each(bufferedRecords, function (buffer) {
 
     var matchingParentRecord = _.find(parentRecords, function (parentRecord) {
-      return parentRecord[buffer.parentPkAttr] === buffer.belongsToPKValue && !matchingParentRecord.found;
+      return parentRecord[buffer.parentPkAttr] === buffer.belongsToPKValue && !parentRecord.found;
     });
 
     // This should always be true, but checking just in case.


### PR DESCRIPTION
I've run into an issue on my project where calling populate or populateAll only populates the first row, and all subsequent rows are left with empty JSON objects without even having the foreignKey.
This is for a simple foreignKey scenario (one-to-many but we don't care about the many).

We've also set a number of properties on the model and some attributes, so please let me know if you'd need info on these.
This is a sails-mysql adapter that we're using.
And it's very possible the problem my exist in the sails-mysql adapter in structuring the buffers, but I don't know what's the expectation of the buffers, so I've simply updated the waterline-cursor code where the population occurs (I believe).

After debugging this code, I believe the issue is that we're looping through the list of all buffers needed to be applied, and then we're finding the row that matches based on foreignKey lookup IDs (or whatever)...
But on each iteration through the buffers list, the rows to match against starts over with the find(aka looping), and I believe that the first row matching will always get returned and have this logic applied over and over again.
